### PR TITLE
Entity field access standard / optimized benchmark

### DIFF
--- a/basic/build.gradle
+++ b/basic/build.gradle
@@ -33,12 +33,12 @@ dependencies {
         testImplementation 'org.hibernate:hibernate-testing-jakarta:5.6.15.Final'
     }
     else if ( "perf" == orm || orm == null ) {
-        testImplementation 'org.hibernate.orm:hibernate-core:6.6.2-SNAPSHOT'
-        testImplementation 'org.hibernate.orm:hibernate-testing:6.6.2-SNAPSHOT'
+        testImplementation 'org.hibernate.orm:hibernate-core:6.6.5-SNAPSHOT'
+        testImplementation 'org.hibernate.orm:hibernate-testing:6.6.5-SNAPSHOT'
     }
     else {
-        testImplementation 'org.hibernate.orm:hibernate-core:6.6.1.Final'
-        testImplementation 'org.hibernate.orm:hibernate-testing:6.6.1.Final'
+        testImplementation 'org.hibernate.orm:hibernate-core:6.6.4.Final'
+        testImplementation 'org.hibernate.orm:hibernate-testing:6.6.4.Final'
     }
 
     //Databases

--- a/basic/src/test/java/org/hibernate/benchmark/enhancement/AccessOptimizers.java
+++ b/basic/src/test/java/org/hibernate/benchmark/enhancement/AccessOptimizers.java
@@ -1,0 +1,426 @@
+package org.hibernate.benchmark.enhancement;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.bytecode.enhance.spi.EnhancementContext;
+import org.hibernate.bytecode.enhance.spi.Enhancer;
+import org.hibernate.bytecode.internal.bytebuddy.BytecodeProviderImpl;
+import org.hibernate.bytecode.spi.BytecodeProvider;
+import org.hibernate.bytecode.spi.ProxyFactoryFactory;
+import org.hibernate.bytecode.spi.ReflectionOptimizer;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.property.access.spi.PropertyAccess;
+
+import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
+import org.hibernate.testing.orm.domain.gambit.EntityOfMaps;
+import org.hibernate.testing.orm.domain.gambit.EntityWithLazyOneToOne;
+import org.hibernate.testing.orm.domain.gambit.EnumValue;
+import org.hibernate.testing.orm.domain.gambit.MutableValue;
+import org.hibernate.testing.orm.domain.gambit.SimpleComponent;
+import org.hibernate.testing.orm.domain.gambit.SimpleEntity;
+
+import jakarta.persistence.metamodel.EntityType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static org.hibernate.internal.util.NullnessUtil.castNonNull;
+
+/**
+ * @author Marco Belladelli
+ */
+@State(Scope.Thread)
+public class AccessOptimizers {
+	public enum Access {
+		STANDARD, OPTIMIZED
+	}
+
+	public enum Morphism {
+		ONE, TWO, THREE, FOUR;
+
+		int types() {
+			return switch ( this ) {
+				case ONE -> 1;
+				case TWO -> 2;
+				case THREE -> 3;
+				case FOUR -> 4;
+			};
+		}
+	}
+
+	@Param
+	private Access access;
+
+	@Param
+	private Morphism morphism;
+
+	// WHen true, we make JIT compile all Morphism versions of the method but then run only 1 type
+	@Param({ "false", "true" })
+	private boolean polluteAtWarmup;
+
+	@Param({ "100" })
+	private int count;
+
+	private SessionFactory sessionFactory;
+	private Session session;
+
+	int nextEntityTypeId;
+	int[] entityTypes;
+
+	@Setup
+	public void setup(Blackhole bh) {
+		int types = morphism.types();
+		if ( types == 1 && polluteAtWarmup ) {
+			// this is fairly useless
+			throw new IllegalStateException( "Cannot pollute with monomorphic types" );
+		}
+		switch ( access ) {
+			case OPTIMIZED -> sessionFactory = getSessionFactory( new TestBytecodeProvider(), types );
+			case STANDARD -> sessionFactory = getSessionFactory( new ProxyOnlyBytecodeProvider(), types );
+		}
+		populateData( sessionFactory, count, types );
+		session = sessionFactory.openSession();
+		session.getTransaction().begin();
+
+		nextEntityTypeId = 0;
+		entityTypes = new int[types];
+		for ( int i = 0; i < types; i++ ) {
+			entityTypes[i] = i;
+		}
+		if ( polluteAtWarmup ) {
+			// this is ensuring that every each queryX method is called enough to be fully compiled
+			for ( int i = 0; i < 10_000; i++ ) {
+				switch ( types ) {
+					case 4:
+						query( EntityOfBasics.class, session, bh );
+					case 3:
+						query( EntityOfMaps.class, session, bh );
+					case 2:
+						query( EntityWithLazyOneToOne.class, session, bh );
+					case 1:
+						query( SimpleEntity.class, session, bh );
+				}
+			}
+			// force to make it monomorphic now
+			entityTypes = new int[] { 0 };
+			nextEntityTypeId = 0;
+		}
+	}
+
+	private int nextEntityTypeId() {
+		var entityTypes = this.entityTypes;
+		if ( nextEntityTypeId >= entityTypes.length ) {
+			nextEntityTypeId = 1;
+			return entityTypes[0];
+		}
+		else {
+			return entityTypes[nextEntityTypeId++];
+		}
+	}
+
+	private void populateData(SessionFactory sf, int count, int types) {
+		if ( types < 1 || types > 4 ) {
+			throw new IllegalArgumentException( "Invalid types" );
+		}
+		final Session session = sf.openSession();
+		session.getTransaction().begin();
+		for ( int i = 1; i <= count; i++ ) {
+			final SimpleEntity simpleEntity = randomSimpleEntity( i );
+			switch ( types ) {
+				case 4:
+					session.persist( randomEntityOfBasics( i ) );
+				case 3:
+					session.persist( randomEntityOfMaps( i, simpleEntity ) );
+				case 2:
+					session.persist( randomEntityWithToOne( i, simpleEntity ) );
+				case 1:
+					session.persist( simpleEntity );
+			}
+		}
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	private static SimpleEntity randomSimpleEntity(int count) {
+		final long timestamp = System.currentTimeMillis() + count * 3_600_000L;
+		return new SimpleEntity(
+				count,
+				new Date( timestamp ),
+				Instant.ofEpochMilli( timestamp ),
+				count,
+				(long) count,
+				"simple_entity_" + count
+		);
+	}
+
+	private static EntityOfMaps randomEntityOfMaps(int count, SimpleEntity simpleEntity) {
+		final EntityOfMaps entity = new EntityOfMaps( count, "entity_of_maps_" + count );
+		entity.setBasicByBasic( Map.of( "key_" + count, "value_" + count ) );
+		entity.setNumberByNumber( Map.of( count, (double) count ) );
+		entity.setSortedBasicByBasic( new TreeMap<>( entity.getBasicByBasic() ) );
+		entity.setSortedBasicByBasicWithComparator( new TreeMap<>( entity.getBasicByBasic() ) );
+		entity.setSortedBasicByBasicWithSortNaturalByDefault( new TreeMap<>( entity.getBasicByBasic() ) );
+		final EnumValue enumValue = switch ( count % 3 ) {
+			case 0 -> EnumValue.ONE;
+			case 1 -> EnumValue.TWO;
+			case 2 -> EnumValue.THREE;
+			default -> throw new IllegalStateException( "Unexpected value: " + count % 3 );
+		};
+		entity.setBasicByEnum( Map.of( enumValue, "value_" + count ) );
+		entity.setBasicByConvertedEnum( Map.of( enumValue, "value_" + count ) );
+		final SimpleComponent simpleComponent = new SimpleComponent(
+				"attribute_" + count,
+				"another_attribute_" + count
+		);
+		entity.setComponentByBasic( Map.of( "key_" + count, simpleComponent ) );
+		entity.setBasicByComponent( Map.of( simpleComponent, "value_" + count ) );
+
+		entity.setOneToManyByBasic( Map.of( "key_" + count, simpleEntity ) );
+		entity.setBasicByOneToMany( Map.of( simpleEntity, "value_" + count ) );
+
+		entity.setManyToManyByBasic( Map.of( "key_" + count, simpleEntity ) );
+		entity.setComponentByBasicOrdered( Map.of( "key_" + count, simpleComponent ) );
+
+		entity.setSortedManyToManyByBasic( new TreeMap<>( entity.getOneToManyByBasic() ) );
+		entity.setSortedManyToManyByBasicWithComparator( new TreeMap<>( entity.getOneToManyByBasic() ) );
+		entity.setSortedManyToManyByBasicWithSortNaturalByDefault( new TreeMap<>( entity.getOneToManyByBasic() ) );
+		return entity;
+	}
+
+	private static EntityWithLazyOneToOne randomEntityWithToOne(int count, SimpleEntity simpleEntity) {
+		final EntityWithLazyOneToOne entity = new EntityWithLazyOneToOne(
+				count,
+				"entity_with_toone_" + count,
+				count
+		);
+		entity.setOther( simpleEntity );
+		return entity;
+	}
+
+	private static EntityOfBasics randomEntityOfBasics(int count) {
+		final long timestamp = System.currentTimeMillis() + count * 3_600_000L;
+		final EntityOfBasics entity = new EntityOfBasics( count );
+		entity.setTheBoolean( count % 2 == 0 );
+		entity.setTheNumericBoolean( count % 2 == 1 );
+		entity.setTheStringBoolean( count % 2 == 0 );
+		entity.setTheString( "entity_of_basics_" + count );
+		entity.setTheInteger( count );
+		entity.setTheInt( count );
+		entity.setTheShort( (short) count );
+		entity.setTheDouble( count );
+		try {
+			entity.setTheUrl( new URL( "http://example.com/" + count ) );
+		}
+		catch (MalformedURLException ignored) {
+		}
+		entity.setTheDate( new Date( timestamp ) );
+		entity.setTheTime( new Date( timestamp ) );
+		entity.setTheTimestamp( new Date( timestamp ) );
+		entity.setTheInstant( Instant.ofEpochMilli( timestamp ) );
+		entity.setGender( entity.isTheBoolean() ? EntityOfBasics.Gender.FEMALE : EntityOfBasics.Gender.MALE );
+		entity.setSingleCharGender( entity.isTheBoolean() ? EntityOfBasics.Gender.FEMALE : EntityOfBasics.Gender.MALE );
+		entity.setConvertedGender( entity.isTheBoolean() ? EntityOfBasics.Gender.FEMALE : EntityOfBasics.Gender.MALE );
+		entity.setOrdinalGender( entity.isTheBoolean() ? EntityOfBasics.Gender.FEMALE : EntityOfBasics.Gender.MALE );
+		entity.setTheDuration( null ); // DurationJavaType wraps BigDecimal using costly division
+		entity.setTheUuid( UUID.randomUUID() );
+		entity.setTheLocalDateTime( LocalDateTime.ofInstant( entity.getTheInstant(), ZoneId.systemDefault() ) );
+		entity.setTheLocalDate( LocalDate.ofInstant( entity.getTheInstant(), ZoneId.systemDefault() ) );
+		entity.setTheLocalTime( LocalTime.ofInstant( entity.getTheInstant(), ZoneId.systemDefault() ) );
+		entity.setTheZonedDateTime( ZonedDateTime.ofInstant( entity.getTheInstant(), ZoneId.systemDefault() ) );
+		entity.setTheOffsetDateTime( OffsetDateTime.ofInstant( entity.getTheInstant(), ZoneId.systemDefault() ) );
+		entity.setMutableValue( new MutableValue( "mutable_value_" + count ) );
+		entity.setTheField( "field_" + count );
+		return entity;
+	}
+
+	protected SessionFactory getSessionFactory(BytecodeProvider bytecodeProvider, int types) {
+		final Configuration config = new Configuration();
+		switch ( types ) {
+			case 4:
+				config.addAnnotatedClass( EntityOfBasics.class );
+			case 3:
+				config.addAnnotatedClass( EntityOfMaps.class );
+			case 2:
+				config.addAnnotatedClass( EntityWithLazyOneToOne.class );
+			case 1:
+				config.addAnnotatedClass( SimpleEntity.class );
+		}
+		final StandardServiceRegistryBuilder srb = config.getStandardServiceRegistryBuilder();
+		srb.applySetting( AvailableSettings.SHOW_SQL, false )
+				.applySetting( AvailableSettings.LOG_SESSION_METRICS, false )
+				.applySetting(
+						AvailableSettings.DIALECT,
+						"org.hibernate.dialect.H2Dialect"
+				)
+				.applySetting( AvailableSettings.JAKARTA_JDBC_DRIVER, "org.h2.Driver" )
+				.applySetting( AvailableSettings.JAKARTA_JDBC_URL, "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1" )
+				.applySetting( AvailableSettings.JAKARTA_JDBC_USER, "sa" )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+		// force no runtime bytecode-enhancement
+		srb.addService( BytecodeProvider.class, bytecodeProvider );
+		final SessionFactoryImplementor sf = (SessionFactoryImplementor) config.buildSessionFactory( srb.build() );
+
+		for ( EntityType<?> entityType : sf.getJpaMetamodel().getEntities() ) {
+			final ReflectionOptimizer optimizer = sf.getMappingMetamodel()
+					.getEntityDescriptor( entityType.getJavaType() )
+					.getRepresentationStrategy()
+					.getReflectionOptimizer();
+			if ( access == Access.STANDARD ) {
+				assert optimizer == null;
+			}
+			else {
+				//noinspection ConstantValue
+				assert optimizer != null && optimizer.getAccessOptimizer() != null;
+			}
+		}
+		return sf;
+	}
+
+	@TearDown
+	public void destroy() {
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@Benchmark
+	public int query(Blackhole bh) {
+		int nextEntityTypeId = nextEntityTypeId();
+		final int count = switch ( nextEntityTypeId ) {
+			case 0 -> query( SimpleEntity.class, session, bh );
+			case 1 -> query( EntityWithLazyOneToOne.class, session, bh );
+			case 2 -> query( EntityOfMaps.class, session, bh );
+			case 3 -> query( EntityOfBasics.class, session, bh );
+			default -> throw new AssertionError( "it shouldn't happen, entity type id: " + nextEntityTypeId );
+		};
+		assert count == this.count;
+		return count;
+	}
+
+	private static int query(Class<?> entityClass, Session session, Blackhole bh) {
+		final List<?> resultList = session.createQuery(
+				"from " + entityClass.getSimpleName(),
+				entityClass
+		).getResultList();
+		int count = 0;
+		for ( Object result : resultList ) {
+			if ( bh != null ) {
+				bh.consume( result );
+			}
+			count++;
+		}
+		session.clear();
+		return count;
+	}
+
+	/**
+	 * Test {@link BytecodeProvider} which provides the different access optimizers
+	 */
+	static class TestBytecodeProvider implements BytecodeProvider {
+		private final BytecodeProviderImpl delegate = new BytecodeProviderImpl();
+
+		@Override
+		public ProxyFactoryFactory getProxyFactoryFactory() {
+			return delegate.getProxyFactoryFactory();
+		}
+
+		@SuppressWarnings("removal")
+		@Override
+		public ReflectionOptimizer getReflectionOptimizer(
+				Class clazz,
+				String[] getterNames,
+				String[] setterNames,
+				Class[] types) {
+			return null;
+		}
+
+		@Override
+		public ReflectionOptimizer getReflectionOptimizer(
+				Class<?> clazz,
+				Map<String, PropertyAccess> propertyAccessMap) {
+			final ReflectionOptimizer optimizer = delegate.getReflectionOptimizer( clazz, propertyAccessMap );
+			return new ReflectionOptimizer() {
+				@Override
+				public InstantiationOptimizer getInstantiationOptimizer() {
+					return null;
+				}
+
+				@Override
+				public AccessOptimizer getAccessOptimizer() {
+					return castNonNull( optimizer ).getAccessOptimizer();
+				}
+			};
+
+		}
+
+		@Override
+		public Enhancer getEnhancer(EnhancementContext enhancementContext) {
+			return null;
+		}
+	}
+
+	/**
+	 * Empty {@link BytecodeProvider} which only provides proxy functionality
+	 */
+	static class ProxyOnlyBytecodeProvider implements BytecodeProvider {
+		private final BytecodeProviderImpl delegate = new BytecodeProviderImpl();
+
+		@Override
+		public ProxyFactoryFactory getProxyFactoryFactory() {
+			return delegate.getProxyFactoryFactory();
+		}
+
+		@SuppressWarnings("removal")
+		@Override
+		public ReflectionOptimizer getReflectionOptimizer(
+				Class clazz,
+				String[] getterNames,
+				String[] setterNames,
+				Class[] types) {
+			return null;
+		}
+
+		@Override
+		public ReflectionOptimizer getReflectionOptimizer(
+				Class<?> clazz,
+				Map<String, PropertyAccess> propertyAccessMap) {
+			return null;
+		}
+
+		@Override
+		public Enhancer getEnhancer(EnhancementContext enhancementContext) {
+			return null;
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		final AccessOptimizers benchmark = new AccessOptimizers();
+		benchmark.morphism = Morphism.FOUR;
+		benchmark.count = 100;
+		benchmark.access = Access.OPTIMIZED;
+
+		benchmark.setup( null );
+		query( SimpleEntity.class, benchmark.session, null );
+	}
+}

--- a/run_AccessOptimizers.sh
+++ b/run_AccessOptimizers.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function usage() {
+  echo "Usage:"
+  echo
+  echo "  $0 <orm_version>"
+  echo
+  echo "    <orm>                The ORM version to test (e.g. 6.6 or perf)"
+}
+
+ORM_VERSION=$1
+
+if [ -z "$ORM_VERSION" ]; then
+	echo "ERROR: ORM version not supplied"
+	usage
+	exit 1
+fi
+
+./gradlew jmhJar -Porm=${ORM_VERSION}
+
+java -jar basic/target/libs/hibernate-orm-benchmark-basic-1.0-SNAPSHOT-jmh.jar AccessOptimizers -ppolluteAtWarmup=false -pmorphism=ONE,FOUR -f 2 -pcount=100 -prof gc -prof "async:rawCommand=features=vtable;event=cpu;output=jfr;dir=/tmp;libPath=${ASYNC_PROFILER_HOME}/lib/libasyncProfiler.so"
+
+# first search for all the jfr files in /tmp which contains AccessOptimizers as name
+# then run the jfr2flame tool to generate the flamegraphs
+
+# Find all jfr files in /tmp containing EntityInstantiators in the name
+jfr_files=$(find /tmp/org.hibernate.benchmark.enhancement.AccessOptimizers*/jfr-cpu.jfr)
+# list the jfr files with some comment in between
+echo "JFR files found:"
+echo $jfr_files
+# Run the jfr2flame tool to generate the flamegraphs
+echo "Flamegraphs produced:"
+for jfr_file in $jfr_files; do
+  java -cp ${ASYNC_PROFILER_HOME}/lib/converter.jar jfr2flame --lines $jfr_file ${jfr_file%.jfr}-cpu.html
+  # print the produced ones
+  echo ${jfr_file%.jfr}-cpu.html
+done


### PR DESCRIPTION
New benchmark which highlights the effects of bytecode enhancement, very similar to https://github.com/hibernate/hibernate-orm-benchmark/pull/13, but this time measuring the impact of using `AccessOptimizer`s to set entity property values instead of relying on reflection. The benchmark is set up by pre-populating the database with `count` (default 100) entities of 1 to 4 different types, and measures querying these entity types, which requires populating all instance's fields with attribute values.

Here are the results (using JDK 17) of running the benchmark with only 1 entity type that has 5 fields:
```
Benchmark                                    (access)  (count)  (morphism)  (polluteAtWarmup)   Mode  Cnt       Score     Error   Units
---------------------------------------------------------------------------------------------------------------------------------------
AccessOptimizers.query                       STANDARD      100         ONE              false  thrpt   10   21879.225 ± 250.198   ops/s
AccessOptimizers.query:·async                STANDARD      100         ONE              false  thrpt              NaN               ---
AccessOptimizers.query:·gc.alloc.rate        STANDARD      100         ONE              false  thrpt   10    1683.248 ±  20.862  MB/sec
AccessOptimizers.query:·gc.alloc.rate.norm   STANDARD      100         ONE              false  thrpt   10   80727.253 ±  19.124    B/op
AccessOptimizers.query:·gc.count             STANDARD      100         ONE              false  thrpt   10     486.000            counts
AccessOptimizers.query:·gc.time              STANDARD      100         ONE              false  thrpt   10     708.000                ms
---------------------------------------------------------------------------------------------------------------------------------------
AccessOptimizers.query                      OPTIMIZED      100         ONE              false  thrpt   10   22532.848 ± 842.096   ops/s
AccessOptimizers.query:·async               OPTIMIZED      100         ONE              false  thrpt              NaN               ---
AccessOptimizers.query:·gc.alloc.rate       OPTIMIZED      100         ONE              false  thrpt   10    1475.201 ±  54.193  MB/sec
AccessOptimizers.query:·gc.alloc.rate.norm  OPTIMIZED      100         ONE              false  thrpt   10   68691.253 ±   0.003    B/op
AccessOptimizers.query:·gc.count            OPTIMIZED      100         ONE              false  thrpt   10     526.000            counts
AccessOptimizers.query:·gc.time             OPTIMIZED      100         ONE              false  thrpt   10     678.000                ms
```

As we can see, the impact of the access optimizers is not very significant, though there is still a small improvement it can be considered within margin of error.

When increasing the entity types to 4, with a varied number of fields (5, 3, 17 and 30), the improvements are significant:
```
Benchmark                                    (access)  (count)  (morphism)  (polluteAtWarmup)   Mode  Cnt       Score     Error   Units
---------------------------------------------------------------------------------------------------------------------------------------
AccessOptimizers.query                       STANDARD      100        FOUR              false  thrpt   10    8819.254 ± 240.060   ops/s
AccessOptimizers.query:·async                STANDARD      100        FOUR              false  thrpt              NaN               ---
AccessOptimizers.query:·gc.alloc.rate        STANDARD      100        FOUR              false  thrpt   10    2221.599 ±  61.311  MB/sec
AccessOptimizers.query:·gc.alloc.rate.norm   STANDARD      100        FOUR              false  thrpt   10  264303.885 ± 343.305    B/op
AccessOptimizers.query:·gc.count             STANDARD      100        FOUR              false  thrpt   10     636.000            counts
AccessOptimizers.query:·gc.time              STANDARD      100        FOUR              false  thrpt   10     815.000                ms
---------------------------------------------------------------------------------------------------------------------------------------
AccessOptimizers.query                      OPTIMIZED      100        FOUR              false  thrpt   10   10120.356 ± 387.230   ops/s
AccessOptimizers.query:·async               OPTIMIZED      100        FOUR              false  thrpt              NaN               ---
AccessOptimizers.query:·gc.alloc.rate       OPTIMIZED      100        FOUR              false  thrpt   10    2249.944 ±  88.825  MB/sec
AccessOptimizers.query:·gc.alloc.rate.norm  OPTIMIZED      100        FOUR              false  thrpt   10  233295.264 ±   2.306    B/op
AccessOptimizers.query:·gc.count            OPTIMIZED      100        FOUR              false  thrpt   10     535.000            counts
AccessOptimizers.query:·gc.time             OPTIMIZED      100        FOUR              false  thrpt   10     892.000                ms
```

Here, we observe the `OPTIMIZED` run saw an increase in ops/s of `14.7%`, with an error rate of `~3%`. Of course, entities with an higher number of properties would accentuate the effect of bytecode optimization, but I testing a lower number of fields should better represent a real-world scenario.

The impact of field access optimization is evident, and this is confirmed by looking at cpu flamegraphs:

- STANDARD
![standard](https://github.com/user-attachments/assets/43ae44c1-2e7a-44fa-94f4-9285f5fc38cb)

- OPTIMIZED
![optimized](https://github.com/user-attachments/assets/fd781ba5-62ff-4ca8-a1ac-1245f5e6f588)

Looking at the line where property values are set (`EntityInitializerImpl.initializeEntityInstance:1345`), we see a match of `8.3%` in the `STANDARD` case vs `2.4%` in the `OPTIMIZED` one. Though there is an `itable stub` call when using bytecode enhancement's `AccessOptimizer` interface method invocations, this still proves better performing when comparing it to reflection in the non-optimized runs.

Note: access optimizers are also used when _reading_ property values, i.e. when flushing newly inserted entities, or existing ones in the persistence context that might be dirty, so enhancement should improve performance there as well.