### PR TITLE
New benchmarks measuring impact of identity hash on persistent entities and collections

### DIFF
--- a/basic/build.gradle
+++ b/basic/build.gradle
@@ -13,6 +13,10 @@ apply from: rootProject.file( 'gradle/databases.gradle' )
 
 repositories {
     mavenLocal()
+
+    maven {
+        url = uri('https://oss.sonatype.org/content/repositories/snapshots/')
+    }
 }
 
 dependencies {
@@ -31,6 +35,10 @@ dependencies {
     else if ( "5.6" == orm ) {
         testImplementation 'org.hibernate:hibernate-core-jakarta:5.6.15.Final'
         testImplementation 'org.hibernate:hibernate-testing-jakarta:5.6.15.Final'
+    }
+    else if ( "7.0" == orm ) {
+        testImplementation 'org.hibernate.orm:hibernate-core:7.0.0-SNAPSHOT'
+        testImplementation 'org.hibernate.orm:hibernate-testing:7.0.0-SNAPSHOT'
     }
     else if ( "perf" == orm || orm == null ) {
         testImplementation 'org.hibernate.orm:hibernate-core:6.6.5-SNAPSHOT'

--- a/basic/src/test/java/org/hibernate/benchmark/collections/PersistentCollections.java
+++ b/basic/src/test/java/org/hibernate/benchmark/collections/PersistentCollections.java
@@ -1,0 +1,229 @@
+package org.hibernate.benchmark.collections;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.hibernate.testing.orm.domain.gambit.EntityOfLists;
+import org.hibernate.testing.orm.domain.gambit.EntityOfMaps;
+import org.hibernate.testing.orm.domain.gambit.SimpleEntity;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Tests the performance of handling persistent collections in the persistence context.
+ */
+@SuppressWarnings("unused")
+@State(Scope.Thread)
+public class PersistentCollections {
+	public enum CollectionType {
+		SET, // 2 collections
+		LIST, // 7 collections
+		MAP; // 16 collections
+
+		int id() {
+			return switch ( this ) {
+				case SET -> 1;
+				case LIST -> 2;
+				case MAP -> 3;
+			};
+		}
+	}
+
+	@Param
+	private CollectionType collections;
+
+	@Param({ "100" })
+	private int count;
+
+	@Param({ "false", "true" })
+	private boolean init_collections;
+
+	private SessionFactory sessionFactory;
+	private Session session;
+
+	@Setup
+	public void setup(Blackhole bh) {
+		final Class<?> entityClass = entityClass( collections.id() );
+		sessionFactory = getSessionFactory( entityClass );
+		populateData( sessionFactory, count, entityClass );
+		session = sessionFactory.openSession();
+		session.getTransaction().begin();
+	}
+
+	@TearDown
+	public void destroy() {
+		session.getTransaction().commit();
+		session.close();
+		sessionFactory.close();
+	}
+
+	private static Class<?> entityClass(int id) {
+		return switch ( id ) {
+			case 3 -> EntityOfMaps.class;
+			case 2 -> EntityOfLists.class;
+			case 1 -> EntityOfSets.class;
+			default -> throw new IllegalStateException( "Unexpected value: " + id );
+		};
+	}
+
+	private static SessionFactory getSessionFactory(Class<?> entityClass) {
+		final Configuration config = new Configuration();
+		// we always need SimpleEntity to be mapped for to-many associations
+		config.addAnnotatedClass( SimpleEntity.class );
+		config.addAnnotatedClass( entityClass );
+		final StandardServiceRegistryBuilder srb = config.getStandardServiceRegistryBuilder();
+		srb.applySetting( AvailableSettings.SHOW_SQL, false )
+				.applySetting( AvailableSettings.LOG_SESSION_METRICS, false )
+				.applySetting( AvailableSettings.DIALECT, "org.hibernate.dialect.H2Dialect" )
+				.applySetting( AvailableSettings.JAKARTA_JDBC_DRIVER, "org.h2.Driver" )
+				.applySetting( AvailableSettings.JAKARTA_JDBC_URL, "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1" )
+				.applySetting( AvailableSettings.JAKARTA_JDBC_USER, "sa" )
+				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+		return config.buildSessionFactory( srb.build() );
+	}
+
+	private void populateData(SessionFactory sf, int count, Class<?> entityClass) {
+		// We don't actually need to populate collections to highlight the performance of the Persistence Context
+		final Session session = sf.openSession();
+		session.getTransaction().begin();
+
+		switch ( entityClass.getSimpleName() ) {
+			case "EntityOfSets":
+				for ( int i = 0; i < count; i++ ) {
+					session.persist( new EntityOfSets( i, "sets_" + i ) );
+				}
+				break;
+			case "EntityOfLists":
+				for ( int i = 0; i < count; i++ ) {
+					session.persist( new EntityOfLists( i, "lists_" + i ) );
+				}
+				break;
+			case "EntityOfMaps":
+				for ( int i = 0; i < count; i++ ) {
+					session.persist( new EntityOfMaps( i, "maps_" + i ) );
+				}
+				break;
+		}
+
+		session.getTransaction().commit();
+		session.close();
+	}
+
+	@Benchmark
+	public int query(Blackhole bh) {
+		final Class<?> entityType = entityClass( collections.id() );
+		final List<?> results = queryEntity( entityType, session );
+		if ( init_collections ) {
+			initCollections( results, entityType );
+		}
+		int resultCount = 0;
+		for ( Object result : results ) {
+			if ( bh != null ) {
+				bh.consume( result );
+			}
+			resultCount++;
+		}
+		session.clear();
+		return resultCount;
+	}
+
+	private static <T> List<T> queryEntity(Class<T> entityClass, Session session) {
+		return session.createQuery(
+				"from " + entityClass.getSimpleName(),
+				entityClass
+		).getResultList();
+	}
+
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	private static void initCollections(List<?> results, Class<?> entityType) {
+		// force initialization of all associated collections
+		switch ( entityType.getSimpleName() ) {
+			case "EntityOfSets":
+				for ( Object result : results ) {
+					final EntityOfSets entityOfSets = (EntityOfSets) result;
+					entityOfSets.getSetOfStrings().size();
+					entityOfSets.getSetOfEntities().size();
+				}
+				break;
+			case "EntityOfLists":
+				for ( Object result : results ) {
+					final EntityOfLists entityOfLists = (EntityOfLists) result;
+					entityOfLists.getListOfBasics().size();
+					entityOfLists.getListOfNumbers().size();
+					entityOfLists.getListOfConvertedEnums().size();
+					entityOfLists.getListOfEnums().size();
+					entityOfLists.getListOfComponents().size();
+					entityOfLists.getListOfOneToMany().size();
+					entityOfLists.getListOfManyToMany().size();
+				}
+				break;
+			case "EntityOfMaps":
+				for ( Object result : results ) {
+					final EntityOfMaps entityOfMaps = (EntityOfMaps) result;
+					entityOfMaps.getBasicByBasic().size();
+					entityOfMaps.getNumberByNumber().size();
+					entityOfMaps.getSortedBasicByBasic().size();
+					entityOfMaps.getSortedBasicByBasicWithComparator().size();
+					entityOfMaps.getSortedBasicByBasicWithSortNaturalByDefault().size();
+					entityOfMaps.getBasicByEnum().size();
+					entityOfMaps.getBasicByConvertedEnum().size();
+					entityOfMaps.getComponentByBasic().size();
+					entityOfMaps.getBasicByComponent().size();
+					entityOfMaps.getOneToManyByBasic().size();
+					entityOfMaps.getBasicByOneToMany().size();
+					entityOfMaps.getManyToManyByBasic().size();
+					entityOfMaps.getComponentByBasicOrdered().size();
+					entityOfMaps.getSortedManyToManyByBasic().size();
+					entityOfMaps.getSortedManyToManyByBasicWithComparator().size();
+					entityOfMaps.getSortedManyToManyByBasicWithSortNaturalByDefault().size();
+				}
+				break;
+		}
+	}
+
+	@Entity(name = "EntityOfSets")
+	private static final class EntityOfSets {
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@ElementCollection
+		private Set<String> setOfStrings;
+
+		@OneToMany
+		private Set<SimpleEntity> setOfEntities;
+
+		public EntityOfSets() {
+		}
+
+		public EntityOfSets(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Set<String> getSetOfStrings() {
+			return setOfStrings;
+		}
+
+		public Set<SimpleEntity> getSetOfEntities() {
+			return setOfEntities;
+		}
+	}
+}

--- a/basic/src/test/java/org/hibernate/benchmark/enhancement/EnhancementUtils.java
+++ b/basic/src/test/java/org/hibernate/benchmark/enhancement/EnhancementUtils.java
@@ -1,0 +1,79 @@
+package org.hibernate.benchmark.enhancement;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.bytecode.enhance.spi.Enhancer;
+
+import org.hibernate.testing.bytecode.enhancement.EnhancerTestContext;
+
+import static org.hibernate.bytecode.internal.BytecodeProviderInitiator.buildDefaultBytecodeProvider;
+
+public class EnhancementUtils {
+	private static class EnhancingClassLoader extends ClassLoader {
+		private final Enhancer enhancer;
+		private final Collection<String> classesToEnhance;
+
+		public EnhancingClassLoader(Enhancer enhancer, Collection<String> classesToEnhance) {
+			this.enhancer = enhancer;
+			this.classesToEnhance = classesToEnhance;
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			if ( classesToEnhance.contains( name ) ) {
+				Class<?> c = findLoadedClass( name );
+				if ( c != null ) {
+					return c;
+				}
+				try (InputStream is = getResourceAsStream( name.replace( '.', '/' ) + ".class" )) {
+					if ( is == null ) {
+						throw new ClassNotFoundException( name + " not found" );
+					}
+					byte[] original = new byte[is.available()];
+					try (BufferedInputStream bis = new BufferedInputStream( is )) {
+						bis.read( original );
+					}
+					byte[] enhanced = enhancer.enhance( name, original );
+					if ( enhanced == null ) {
+						return defineClass( name, original, 0, original.length );
+					}
+					Path f = Files.createTempDirectory( "" ).getParent()
+							.resolve( name.replace( ".", File.separator ) + ".class" );
+					Files.createDirectories( f.getParent() );
+					try (OutputStream out = Files.newOutputStream( f )) {
+						out.write( enhanced );
+					}
+					return defineClass( name, enhanced, 0, enhanced.length );
+				}
+				catch (Exception t) {
+					throw new ClassNotFoundException( name + " not found", t );
+				}
+			}
+			return getParent().loadClass( name );
+		}
+	}
+
+	/**
+	 * Utility that creates a {@link ClassLoader} that applies bytecode enhancement to classes at runtime.
+	 * Note that if using this you need to use {@link Object} instead of the actual entity class
+	 * in test code to avoid running into CCEs and other problems.
+	 *
+	 * @param classesToEnhance collection used to filter which classes to apply enhancement to
+	 *
+	 * @return the class loader that can be applied via {@link BootstrapServiceRegistryBuilder#applyClassLoader(ClassLoader)}
+	 */
+	public static ClassLoader buildEnhancerClassLoader(Collection<String> classesToEnhance) {
+		final EnhancerTestContext enhancerContext = new EnhancerTestContext();
+		return new EnhancingClassLoader(
+				buildDefaultBytecodeProvider().getEnhancer( enhancerContext ),
+				classesToEnhance
+		);
+	}
+}

--- a/basic/src/test/java/org/hibernate/benchmark/enhancement/EntityInstantiators.java
+++ b/basic/src/test/java/org/hibernate/benchmark/enhancement/EntityInstantiators.java
@@ -43,13 +43,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import static org.hibernate.benchmark.enhancement.EnhancementUtils.buildEnhancerClassLoader;
@@ -577,5 +575,19 @@ public class EntityInstantiators {
 				}
 			};
 		}
+	}
+
+	public static void main(String[] args) {
+		final EntityInstantiators bench = new EntityInstantiators();
+		bench.instantiation = Instantiation.STANDARD;
+		bench.polluteAtWarmup = false;
+		bench.morphism = Morphism.QUAD;
+		bench.enhance = true;
+		bench.count = 10;
+		bench.mutable = true;
+
+		bench.setup( null );
+
+		bench.query( null );
 	}
 }

--- a/basic/src/test/java/org/hibernate/benchmark/enhancement/EntityInstantiators.java
+++ b/basic/src/test/java/org/hibernate/benchmark/enhancement/EntityInstantiators.java
@@ -1,14 +1,19 @@
 package org.hibernate.benchmark.enhancement;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.bytecode.enhance.spi.EnhancementContext;
 import org.hibernate.bytecode.enhance.spi.Enhancer;
@@ -29,16 +34,25 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.proxy.ProxyFactory;
 import org.hibernate.type.CompositeType;
 
+import org.hibernate.testing.orm.domain.gambit.EntityOfBasics;
+import org.hibernate.testing.orm.domain.gambit.EntityOfMaps;
+import org.hibernate.testing.orm.domain.gambit.EntityWithLazyOneToOne;
+import org.hibernate.testing.orm.domain.gambit.SimpleEntity;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+
+import static org.hibernate.benchmark.enhancement.EnhancementUtils.buildEnhancerClassLoader;
 
 /**
  * @author Marco Belladelli
@@ -69,12 +83,20 @@ public class EntityInstantiators {
 	@Param
 	private Morphism morphism;
 
-	// WHen true, we make JIT compile all Morphism versions of the method but then run only 1 type
+	// When true, we make JIT compile all Morphism versions of the method but then run only 1 type
 	@Param({ "false", "true" })
 	private boolean polluteAtWarmup;
 
 	@Param({ "100" })
 	private int count;
+
+	// When true, use immutable entities
+	@Param({ "false", "true" })
+	private boolean mutable;
+
+	// When true, enhance entity classes at runtime
+	@Param({ "false", "true" })
+	private boolean enhance;
 
 	private SessionFactory sessionFactory;
 	private Session session;
@@ -89,19 +111,17 @@ public class EntityInstantiators {
 			// this is fairly useless
 			throw new IllegalStateException( "Cannot pollute with monomorphic types" );
 		}
+		final List<Class<?>> entityClasses = initEntityClasses( types, mutable );
+		populateData( getSessionFactory( new BytecodeProviderImpl(), entityClasses, false ), count, types );
 		switch ( instantiation ) {
-			case OPTIMIZED -> sessionFactory = getSessionFactory(
-					new FortuneBytecodeProvider(),
-					EntityInstantiatorPojoOptimized.class,
-					types
-			);
-			case STANDARD -> sessionFactory = getSessionFactory(
-					new BytecodeProviderImpl(),
-					EntityInstantiatorPojoStandard.class,
-					types
-			);
+			case OPTIMIZED:
+				sessionFactory = getSessionFactory( new FortuneBytecodeProvider(), entityClasses, enhance );
+				assertEntityInstantiators( sessionFactory, EntityInstantiatorPojoOptimized.class, types );
+				break;
+			case STANDARD:
+				sessionFactory = getSessionFactory( new BytecodeProviderImpl(), entityClasses, enhance );
+				assertEntityInstantiators( sessionFactory, EntityInstantiatorPojoStandard.class, types );
 		}
-		populateData( sessionFactory, count, types );
 		session = sessionFactory.openSession();
 		session.getTransaction().begin();
 
@@ -115,13 +135,13 @@ public class EntityInstantiators {
 			for ( int i = 0; i < 10_000; i++ ) {
 				switch ( types ) {
 					case 4:
-						queryFortune3( session, bh );
+						queryFortune( fortune3Class(), session, bh );
 					case 3:
-						queryFortune2( session, bh );
+						queryFortune( fortune2Class(), session, bh );
 					case 2:
-						queryFortune1( session, bh );
+						queryFortune( fortune1Class(), session, bh );
 					case 1:
-						queryFortune0( session, bh );
+						queryFortune( fortune0Class(), session, bh );
 				}
 			}
 			// force to make it monomorphic now
@@ -145,76 +165,97 @@ public class EntityInstantiators {
 		if ( types == 0 || types > 4 ) {
 			throw new IllegalArgumentException( "Invalid types" );
 		}
+		sf.getSchemaManager().exportMappedObjects( false );
 		final Session session = sf.openSession();
 		session.getTransaction().begin();
 		switch ( types ) {
 			case 4:
 				for ( int i = 0; i < count; i++ ) {
-					session.persist( new Fortune3( i ) );
+					session.persist( mutable ? new Fortune3( i ) : new Fortune3Immutable( i ) );
 				}
 			case 3:
 				for ( int i = 0; i < count; i++ ) {
-					session.persist( new Fortune2( i ) );
+					session.persist( mutable ? new Fortune2( i ) : new Fortune2Immutable( i ) );
 				}
 			case 2:
 				for ( int i = 0; i < count; i++ ) {
-					session.persist( new Fortune1( i ) );
+					session.persist( mutable ? new Fortune1( i ) : new Fortune1Immutable( i ) );
 				}
 			case 1:
 				for ( int i = 0; i < count; i++ ) {
-					session.persist( new Fortune0( i ) );
+					session.persist( mutable ? new Fortune0( i ) : new Fortune0Immutable( i ) );
 				}
 		}
 		session.getTransaction().commit();
 		session.close();
+		sf.close();
 	}
 
-	protected SessionFactory getSessionFactory(
-			BytecodeProvider bytecodeProvider,
-			Class<?> expectedInstantiatorClass,
-			int types) {
-		final Configuration config = new Configuration();
+	private List<Class<?>> initEntityClasses(int types, boolean mutable) {
+		final List<Class<?>> classes = new ArrayList<>();
 		switch ( types ) {
 			case 4:
-				config.addAnnotatedClass( Fortune3.class );
+				classes.add( fortune3Class() );
 			case 3:
-				config.addAnnotatedClass( Fortune2.class );
+				classes.add( fortune2Class() );
 			case 2:
-				config.addAnnotatedClass( Fortune1.class );
+				classes.add( fortune1Class() );
 			case 1:
-				config.addAnnotatedClass( Fortune0.class );
+				classes.add( fortune0Class() );
 		}
+		return classes;
+	}
+
+	private SessionFactory getSessionFactory(
+			BytecodeProvider bytecodeProvider,
+			List<Class<?>> entityClasses,
+			boolean enhance) {
+		final BootstrapServiceRegistryBuilder bsrb = new BootstrapServiceRegistryBuilder();
+		if ( enhance ) {
+			final ClassLoader enhancerClassLoader = buildEnhancerClassLoader(
+					entityClasses.stream().map( Class::getName ).collect( Collectors.toSet() )
+			);
+			bsrb.applyClassLoader( enhancerClassLoader );
+		}
+		final Configuration config = new Configuration( bsrb.build() );
+		entityClasses.forEach( config::addAnnotatedClass );
 		final StandardServiceRegistryBuilder srb = config.getStandardServiceRegistryBuilder();
 		srb.applySetting( AvailableSettings.SHOW_SQL, false )
 				.applySetting( AvailableSettings.LOG_SESSION_METRICS, false )
 				.applySetting( AvailableSettings.DIALECT, "org.hibernate.dialect.H2Dialect" )
 				.applySetting( AvailableSettings.JAKARTA_JDBC_DRIVER, "org.h2.Driver" )
 				.applySetting( AvailableSettings.JAKARTA_JDBC_URL, "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1" )
-				.applySetting( AvailableSettings.JAKARTA_JDBC_USER, "sa" )
-				.applySetting( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
+				.applySetting( AvailableSettings.JAKARTA_JDBC_USER, "sa" );
 		// force no runtime bytecode-enhancement
 		srb.addService( BytecodeProvider.class, bytecodeProvider );
-		final SessionFactoryImplementor sf = (SessionFactoryImplementor) config.buildSessionFactory( srb.build() );
+		return config.buildSessionFactory( srb.build() );
+	}
+
+	private void assertEntityInstantiators(
+			SessionFactory sessionFactory,
+			Class<?> expectedInstantiatorClass,
+			int types) {
 		final EntityInstantiator[] instantiators = new EntityInstantiator[types];
+		final SessionFactoryImplementor sf = (SessionFactoryImplementor) sessionFactory;
 		switch ( types ) {
 			case 4:
 				instantiators[3] = sf.getMappingMetamodel()
-						.getEntityDescriptor( Fortune3.class )
+						.getEntityDescriptor( fortune3Class() )
 						.getRepresentationStrategy()
 						.getInstantiator();
 			case 3:
 				instantiators[2] = sf.getMappingMetamodel()
-						.getEntityDescriptor( Fortune2.class )
+						.getEntityDescriptor( fortune2Class() )
 						.getRepresentationStrategy()
 						.getInstantiator();
 			case 2:
 				instantiators[1] = sf.getMappingMetamodel()
-						.getEntityDescriptor( Fortune1.class )
+						.getEntityDescriptor( fortune1Class() )
 						.getRepresentationStrategy()
 						.getInstantiator();
 			case 1:
 				instantiators[0] = sf.getMappingMetamodel()
-						.getEntityDescriptor( Fortune0.class )
+						.getEntityDescriptor( fortune0Class() )
 						.getRepresentationStrategy()
 						.getInstantiator();
 		}
@@ -225,45 +266,40 @@ public class EntityInstantiators {
 		if ( !found ) {
 			throw new AssertionFailure( "Expected instantiator not found" );
 		}
-		return sf;
 	}
 
 	@TearDown
 	public void destroy() {
 		session.getTransaction().commit();
 		session.close();
+		sessionFactory.getSchemaManager().dropMappedObjects( false );
+		sessionFactory.close();
 	}
 
 	@Benchmark
 	public int query(Blackhole bh) {
 		int nextEntityTypeId = nextEntityTypeId();
-		final int count;
-		switch ( nextEntityTypeId ) {
-			case 0:
-				count = queryFortune0( session, bh );
-				break;
-			case 1:
-				count = queryFortune1( session, bh );
-				break;
-			case 2:
-				count = queryFortune2( session, bh );
-				break;
-			case 3:
-				count = queryFortune3( session, bh );
-				break;
-			default:
-				throw new AssertionError( "it shouldn't happen!" );
-		}
+		final int count = switch ( nextEntityTypeId ) {
+			case 0 -> queryFortune( fortune0Class(), session, bh );
+			case 1 -> queryFortune( fortune1Class(), session, bh );
+			case 2 -> queryFortune( fortune2Class(), session, bh );
+			case 3 -> queryFortune( fortune3Class(), session, bh );
+			default -> throw new AssertionError( "it shouldn't happen!" );
+		};
+		assert count == this.count;
 		return count;
 	}
 
 	@CompilerControl(CompilerControl.Mode.DONT_INLINE)
-	private static int queryFortune2(Session session, Blackhole bh) {
-		final List<Fortune2> results = session.createQuery( "from Fortune2", Fortune2.class ).getResultList();
+	private static int queryFortune(Class<?> entityClass, Session session, Blackhole bh) {
+		final List<Object> results = session.createQuery(
+				"from " + entityClass.getSimpleName(),
+				Object.class
+		).getResultList();
 		int count = 0;
-		for ( Fortune2 fortune : results ) {
+		for ( Object result : results ) {
 			if ( bh != null ) {
-				bh.consume( fortune );
+				bh.consume( result );
 			}
 			count++;
 		}
@@ -271,46 +307,20 @@ public class EntityInstantiators {
 		return count;
 	}
 
-	@CompilerControl(CompilerControl.Mode.DONT_INLINE)
-	private static int queryFortune3(Session session, Blackhole bh) {
-		final List<Fortune3> results = session.createQuery( "from Fortune3", Fortune3.class ).getResultList();
-		int count = 0;
-		for ( Fortune3 fortune : results ) {
-			if ( bh != null ) {
-				bh.consume( fortune );
-			}
-			count++;
-		}
-		session.clear();
-		return count;
+	private Class<?> fortune0Class() {
+		return mutable ? Fortune0.class : Fortune0Immutable.class;
 	}
 
-	@CompilerControl(CompilerControl.Mode.DONT_INLINE)
-	private static int queryFortune1(Session session, Blackhole bh) {
-		final List<Fortune1> results = session.createQuery( "from Fortune1", Fortune1.class ).getResultList();
-		int count = 0;
-		for ( Fortune1 fortune : results ) {
-			if ( bh != null ) {
-				bh.consume( fortune );
-			}
-			count++;
-		}
-		session.clear();
-		return count;
+	private Class<?> fortune1Class() {
+		return mutable ? Fortune1.class : Fortune1Immutable.class;
 	}
 
-	@CompilerControl(CompilerControl.Mode.DONT_INLINE)
-	private static int queryFortune0(Session session, Blackhole bh) {
-		final List<Fortune0> results = session.createQuery( "from Fortune0", Fortune0.class ).getResultList();
-		int count = 0;
-		for ( Fortune0 fortune0 : results ) {
-			if ( bh != null ) {
-				bh.consume( fortune0 );
-			}
-			count++;
-		}
-		session.clear();
-		return count;
+	private Class<?> fortune2Class() {
+		return mutable ? Fortune2.class : Fortune2Immutable.class;
+	}
+
+	private Class<?> fortune3Class() {
+		return mutable ? Fortune3.class : Fortune3Immutable.class;
 	}
 
 	@Entity(name = "Fortune0")
@@ -322,6 +332,20 @@ public class EntityInstantiators {
 		}
 
 		public Fortune0(Integer id) {
+			this.id = id;
+		}
+	}
+
+	@Immutable
+	@Entity(name = "Fortune0Immutable")
+	static class Fortune0Immutable {
+		@Id
+		public Integer id;
+
+		public Fortune0Immutable() {
+		}
+
+		public Fortune0Immutable(Integer id) {
 			this.id = id;
 		}
 	}
@@ -339,6 +363,20 @@ public class EntityInstantiators {
 		}
 	}
 
+	@Immutable
+	@Entity(name = "Fortune1Immutable")
+	static class Fortune1Immutable {
+		@Id
+		public Integer id;
+
+		public Fortune1Immutable() {
+		}
+
+		public Fortune1Immutable(Integer id) {
+			this.id = id;
+		}
+	}
+
 	@Entity(name = "Fortune2")
 	static class Fortune2 {
 		@Id
@@ -352,6 +390,20 @@ public class EntityInstantiators {
 		}
 	}
 
+	@Immutable
+	@Entity(name = "Fortune2Immutable")
+	static class Fortune2Immutable {
+		@Id
+		public Integer id;
+
+		public Fortune2Immutable() {
+		}
+
+		public Fortune2Immutable(Integer id) {
+			this.id = id;
+		}
+	}
+
 	@Entity(name = "Fortune3")
 	static class Fortune3 {
 		@Id
@@ -361,6 +413,20 @@ public class EntityInstantiators {
 		}
 
 		public Fortune3(Integer id) {
+			this.id = id;
+		}
+	}
+
+	@Immutable
+	@Entity(name = "Fortune3Immutable")
+	static class Fortune3Immutable {
+		@Id
+		public Integer id;
+
+		public Fortune3Immutable() {
+		}
+
+		public Fortune3Immutable(Integer id) {
 			this.id = id;
 		}
 	}

--- a/run_EntityInstantiators.sh
+++ b/run_EntityInstantiators.sh
@@ -18,7 +18,8 @@ fi
 
 ./gradlew jmhJar -Porm=${ORM_VERSION}
 
-java -jar basic/target/libs/hibernate-orm-benchmark-basic-1.0-SNAPSHOT-jmh.jar EntityInstantiators -ppolluteAtWarmup=false -pmorphism=MONO,QUAD -f 2 -pcount=100 -prof gc -prof "async:rawCommand=features=vtable;event=cpu;output=jfr;dir=/tmp;libPath=${ASYNC_PROFILER_HOME}/lib/libasyncProfiler.so"
+java -jar basic/target/libs/hibernate-orm-benchmark-basic-1.0-SNAPSHOT-jmh.jar EntityInstantiators -ppolluteAtWarmup=false -pmorphism=MONO,QUAD -penhance=false -p mutable=true -pcount=100 \
+ -f 2 -prof gc -prof "async:rawCommand=features=vtable;event=cpu;output=jfr;dir=/tmp;libPath=${ASYNC_PROFILER_HOME}/lib/libasyncProfiler.so"
 
 # first search for all the jfr files in /tmp which contains EntityInstantiators as name
 # then run the jfr2flame tool to generate the flamegraphs

--- a/run_PersistentCollections.sh
+++ b/run_PersistentCollections.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function usage() {
+  echo "Usage:"
+  echo
+  echo "  $0 <orm_version>"
+  echo
+  echo "    <orm>                The ORM version to test (e.g. 6.6 or perf)"
+}
+
+ORM_VERSION=$1
+
+if [ -z "$ORM_VERSION" ]; then
+	echo "ERROR: ORM version not supplied"
+	usage
+	exit 1
+fi
+
+./gradlew jmhJar -Porm=${ORM_VERSION}
+
+java -jar basic/target/libs/hibernate-orm-benchmark-basic-1.0-SNAPSHOT-jmh.jar PersistentCollections -pcount=100 -pinit_collections=false \
+ -f 2 -prof gc -prof "async:rawCommand=features=vtable;event=cpu;output=jfr;dir=/tmp;libPath=${ASYNC_PROFILER_HOME}/lib/libasyncProfiler.so"
+
+# first search for all the jfr files in /tmp which contains PersistentCollections as name
+# then run the jfr2flame tool to generate the flamegraphs
+
+# Find all jfr files in /tmp containing PersistentCollections in the name
+jfr_files=$(find /tmp/org.hibernate.benchmark.collections.PersistentCollections*/jfr-cpu.jfr)
+# list the jfr files with some comment in between
+echo "JFR files found:"
+echo $jfr_files
+# Run the jfr2flame tool to generate the flamegraphs
+echo "Flamegraphs produced:"
+for jfr_file in $jfr_files; do
+  java -cp ${ASYNC_PROFILER_HOME}/lib/converter.jar jfr2flame --lines $jfr_file ${jfr_file%.jfr}-cpu.html
+  # print the produced ones
+  echo ${jfr_file%.jfr}-cpu.html
+done


### PR DESCRIPTION
While measuring performance on previous benchmarks (see https://github.com/hibernate/hibernate-orm-benchmark/pull/14 and https://github.com/hibernate/hibernate-orm-benchmark/pull/13), the impact of using `IdentityHashMap`s to track instances in the persistence context was very much evident, and highlighted the importance of evaluating possible alternatives to relying on identity has to track instances: https://hibernate.atlassian.net/browse/HHH-18326.

In particular, the problem exists for:
- non bytecode-enhanced entities, which we have no way of tracking other than their identity hash
- immutable bytecode-enhanced entities, we also need to track these instances as their enhanced entity entry cannot store all information needed due to being immutable
- (**this is new!**) persistent collections, as we also track those in `org.hibernate.engine.internal.StatefulPersistenceContext#collectionEntries`

I found out about the last point while running an unrelated benchmark (measuring bytecode enhanced batch field access vs reflection), that had an entity with several persistent collections as properties. The impact of this was very relevant, as much that I decided to not use an entity including collections to prevent it tainting the test results.


This PR expands on the `EntityInstantiators` benchmark, adding parameters to control whether to bytecode enhance the entities and use `@Immutable` versions of the mappings, to highlight the impact of using identity hash. Here are some results with the current Hibernate version (I used `7.0.0-SNAPSHOT` for testing) with a count of `100` and `1000` entities:

```
Benchmark                                      (count)  (enhance)  (instantiation)  (morphism)  (mutable)  (polluteAtWarmup)   Mode  Cnt       Score      Error   Units

EntityInstantiators.query                          100       true         STANDARD        QUAD      false              false  thrpt   10   46327.453 ± 1989.240   ops/s
EntityInstantiators.query:·async                   100       true         STANDARD        QUAD      false              false  thrpt              NaN                ---
EntityInstantiators.query:·gc.alloc.rate           100       true         STANDARD        QUAD      false              false  thrpt   10    1591.368 ±   68.705  MB/sec
EntityInstantiators.query:·gc.alloc.rate.norm      100       true         STANDARD        QUAD      false              false  thrpt   10   36055.330 ±   19.122    B/op
EntityInstantiators.query:·gc.count                100       true         STANDARD        QUAD      false              false  thrpt   10     484.000             counts
EntityInstantiators.query:·gc.time                 100       true         STANDARD        QUAD      false              false  thrpt   10     724.000                 ms

EntityInstantiators.query                          100       true         STANDARD        QUAD       true              false  thrpt   10   48475.417 ± 2984.754   ops/s
EntityInstantiators.query:·async                   100       true         STANDARD        QUAD       true              false  thrpt              NaN                ---
EntityInstantiators.query:·gc.alloc.rate           100       true         STANDARD        QUAD       true              false  thrpt   10    1556.529 ±   94.673  MB/sec
EntityInstantiators.query:·gc.alloc.rate.norm      100       true         STANDARD        QUAD       true              false  thrpt   10   33699.323 ±    0.231    B/op
EntityInstantiators.query:·gc.count                100       true         STANDARD        QUAD       true              false  thrpt   10     424.000             counts
EntityInstantiators.query:·gc.time                 100       true         STANDARD        QUAD       true              false  thrpt   10     751.000                 ms

EntityInstantiators.query                         1000       true         STANDARD        QUAD      false              false  thrpt   10    4848.596 ±  157.292   ops/s
EntityInstantiators.query:·async                  1000       true         STANDARD        QUAD      false              false  thrpt              NaN                ---
EntityInstantiators.query:·gc.alloc.rate          1000       true         STANDARD        QUAD      false              false  thrpt   10    1587.323 ±   50.781  MB/sec
EntityInstantiators.query:·gc.alloc.rate.norm     1000       true         STANDARD        QUAD      false              false  thrpt   10  343603.988 ±   25.602    B/op
EntityInstantiators.query:·gc.count               1000       true         STANDARD        QUAD      false              false  thrpt   10     436.000             counts`
EntityInstantiators.query:·gc.time                1000       true         STANDARD        QUAD      false              false  thrpt   10     714.000                 ms

EntityInstantiators.query                         1000       true         STANDARD        QUAD       true              false  thrpt   10    5361.566 ±  200.309   ops/s
EntityInstantiators.query:·async                  1000       true         STANDARD        QUAD       true              false  thrpt              NaN                ---
EntityInstantiators.query:·gc.alloc.rate          1000       true         STANDARD        QUAD       true              false  thrpt   10    1632.879 ±   60.380  MB/sec
EntityInstantiators.query:·gc.alloc.rate.norm     1000       true         STANDARD        QUAD       true              false  thrpt   10  319571.926 ±   25.575    B/op
EntityInstantiators.query:·gc.count               1000       true         STANDARD        QUAD       true              false  thrpt   10     450.000             counts
EntityInstantiators.query:·gc.time                1000       true         STANDARD        QUAD       true              false  thrpt   10     680.000                 ms
```

Flamegraph for count `1_000` with **mutable** entities:
![image](https://github.com/user-attachments/assets/acf7d01f-19d0-4acd-b328-d0718152aaf4)

Flamegraph for count `1_000` with **immutable** entities:
![image](https://github.com/user-attachments/assets/bc8574c9-1997-4491-b2f2-0a394a31bb0a)

Zoom to `StatefulPersistenceContext.addEntry`:
![image](https://github.com/user-attachments/assets/ad09ef49-5aaf-4427-9c85-cb614d21ad89)


We can see that:
- count `100`: `4.63%` more ops/s when mutable, `java/util/IdentityHashMap.put` matches `8.87%`
- count `1_000`: `10.58%` more ops/s when mutable, `java/util/IdentityHashMap.put` matches `8.80%` match

In total, `StatefulPersistenceContext.addEntry` matched:
- count `100`: `21.31%` with mutable false, `13.08%` mutable true
- count `1_000`: `22.19%` with mutable false, `14.49%` mutable false



We can clearly see that identity hash maps are the main culprit in the performance penalty we see with immutable entities.


I also added a new `PersistentCollections` benchmark, which tests the collection aspect. It uses 3 entity mappings, `SET` which has 2 collections, `LIST` which has 7 and `MAP` which has 16, to see the impact when using a different number of collections. Here are the results:

```
Benchmark                                        (collections)  (count)  (init_collections)   Mode  Cnt       Score     Error   Units

PersistentCollections.query                                SET      100               false  thrpt   10   20633.665 ± 268.604   ops/s
PersistentCollections.query:·async                         SET      100               false  thrpt              NaN               ---
PersistentCollections.query:·gc.alloc.rate                 SET      100               false  thrpt   10    1820.120 ±  24.281  MB/sec
PersistentCollections.query:·gc.alloc.rate.norm            SET      100               false  thrpt   10   92587.355 ±   0.322    B/op
PersistentCollections.query:·gc.count                      SET      100               false  thrpt   10     463.000            counts
PersistentCollections.query:·gc.time                       SET      100               false  thrpt   10     907.000                ms

PersistentCollections.query                               LIST      100               false  thrpt   10   10229.652 ± 151.821   ops/s
PersistentCollections.query:·async                        LIST      100               false  thrpt              NaN               ---
PersistentCollections.query:·gc.alloc.rate                LIST      100               false  thrpt   10    2366.693 ±  35.512  MB/sec
PersistentCollections.query:·gc.alloc.rate.norm           LIST      100               false  thrpt   10  242791.687 ±  19.175    B/op
PersistentCollections.query:·gc.count                     LIST      100               false  thrpt   10     483.000            counts
PersistentCollections.query:·gc.time                      LIST      100               false  thrpt   10    1048.000                ms

PersistentCollections.query                                MAP      100               false  thrpt   10    5509.648 ±  35.509   ops/s
PersistentCollections.query:·async                         MAP      100               false  thrpt              NaN               ---
PersistentCollections.query:·gc.alloc.rate                 MAP      100               false  thrpt   10    2768.651 ±  17.213  MB/sec
PersistentCollections.query:·gc.alloc.rate.norm            MAP      100               false  thrpt   10  527420.792 ±   4.799    B/op
PersistentCollections.query:·gc.count                      MAP      100               false  thrpt   10     521.000            counts
PersistentCollections.query:·gc.time                       MAP      100               false  thrpt   10    1194.000                ms
```

Flamegraph for SET:
![image](https://github.com/user-attachments/assets/a4a72e13-72fc-43d0-a245-e9769e7b777e)

Zoom to `StatefulPersistenceContext.addCollection`:
![image](https://github.com/user-attachments/assets/dd9fee07-45e4-489e-a4e3-924b1171e294)

Looking at flamegraphs, we see that `StatefulPersistenceContext.addCollection` matches:
- SET: `17.37%`
- LIST: `32.12%`
- MAP: `37.37%`

This bench is leaving all collections uninitialized, so the impact of adding them to the persistence context is very evident. Even if we do initialize them though, benchmark parameter `initialize_collections` using lazy-initialization which is the "slowest" option requiring 1 query for each collection, we still see the impact of identity hash maps with matches of `~3%` in the flamegraphs.